### PR TITLE
Link to harfbuzz-icu library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 CFLAGS=--std=c99 -g -O2 -Wall --pedantic `freetype-config --cflags`
 LDFLAGS=`icu-config --ldflags`
-LIBS=-lcairo -lSDL -lharfbuzz `freetype-config --libs`
+LIBS=-lcairo -lSDL -lharfbuzz -lharfbuzz-icu `freetype-config --libs`
 
 all: ex-sdl-cairo-freetype-harfbuzz
 


### PR DESCRIPTION
ICU is now a separate library, need to link it or the function hb_icu_get_unicode_funcs will be undefined.
