### PR TITLE
Handle SDL_QUIT event

### DIFF
--- a/ex-sdl-cairo-freetype-harfbuzz.c
+++ b/ex-sdl-cairo-freetype-harfbuzz.c
@@ -216,6 +216,10 @@ int main () {
                     }
                     break;
 
+	        case SDL_QUIT:
+                    done = 1;
+                    break;
+
                 case SDL_VIDEORESIZE:
                     width = event.resize.w;
                     height = event.resize.h;


### PR DESCRIPTION
This way when you close the window the process will finish, instead of holding the terminal/console or stuck in the background.
