### PR TITLE
fix osx build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
-CFLAGS=--std=c99 -g -O2 -Wall --pedantic `freetype-config --cflags`
+CFLAGS=--std=c99 -g -O2 -Wall --pedantic `freetype-config --cflags` `sdl-config --cflags`
 LDFLAGS=`icu-config --ldflags`
-LIBS=-lcairo -lSDL -lharfbuzz -lharfbuzz-icu `freetype-config --libs`
+LIBS=-lcairo -lharfbuzz -lharfbuzz-icu `freetype-config --libs` `sdl-config --libs`
 
 all: ex-sdl-cairo-freetype-harfbuzz
 


### PR DESCRIPTION
This fixes the build on OSX 10.9 with SDL installed using homebrew. I've checked that it still compiles on Linux.
