### PR TITLE
fixed compile on linux (ubuntu 18.04)

### DIFF
--- a/ex-sdl-cairo-freetype-harfbuzz.c
+++ b/ex-sdl-cairo-freetype-harfbuzz.c
@@ -7,9 +7,9 @@
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
-#include <ftadvanc.h>
-#include <ftsnames.h>
-#include <tttables.h>
+#include <freetype/ftadvanc.h>
+#include <freetype/ftsnames.h>
+#include <freetype/tttables.h>
 
 #include <harfbuzz/hb.h>
 #include <harfbuzz/hb-ft.h>


### PR DESCRIPTION
This fixes the paths to freetype include in the latest linux distros (tested on ubuntu 18.04)