### PR TITLE
Expand example with FontConfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
-CFLAGS=--std=c99 -g -O2 -Wall --pedantic `pkg-config --cflags freetype2` `sdl2-config --cflags`
-LIBS=-lcairo -lharfbuzz -lharfbuzz-icu `pkg-config --libs freetype2` `sdl2-config --libs`
+CFLAGS=--std=c99 -g -O2 -Wall --pedantic `pkg-config --cflags "fontconfig"` `pkg-config --cflags freetype2` `sdl2-config --cflags`
+LIBS=-lcairo -lharfbuzz -lharfbuzz-icu `pkg-config --libs "fontconfig"` `pkg-config --libs freetype2` `sdl2-config --libs`
 
 all: ex-sdl-cairo-freetype-harfbuzz
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This is a simplish sample application to get from zero to rendering unicode
-text using harfbuzz to do the text layout, freetype for the underlying font
+text using harfbuzz to do the text layout, freetype and fontconfig for the underlying font
 magic, cairo for the anti-aliased font rasterization, and SDL to create the
 window to display stuff in.
 


### PR DESCRIPTION
Thanks for the great example, I need to also use FontConfig to find the right font file, so I figured i'd use your example for testing. And that I may as well send it back if you'd like to incorporate it.